### PR TITLE
Easier installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Customized Firefox appearance with CSS
 ![screenshot](screenshot.PNG)  
 
 ## Installation
-- Go to about:config, search toolkit.legacyUserProfileCustomizations.stylesheets, and set it to true  
+- Go to about:config, search `toolkit.legacyUserProfileCustomizations.stylesheets`, and set it to `true`  
 - Go to about:profiles, then click open folder next to Root Directory
-- Create a folder, name it chrome, right click it to open it in terminal, then run git clone https://github.com/benman604/userChrome.css.git
+- Open your terminal in the previous folder and run the following command: `git clone https://github.com/benman604/userChrome.css.git chrome`


### PR DESCRIPTION
Removed a few unnecessary steps.

If you followed the steps as they were, you'd still need to move the cloned files out of `userChrome.css` into `chrome`. It's easier to just run `git clone` with an argument that creates the `chrome` folder and clones the repo there.